### PR TITLE
Remove unused testCommand and ensure no console.log in tests (fixes #11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Ash Studio",
   "description": "Ash Framework VSCode Extension",
   "publisher": "ketupia",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/src/features/ashCodeLensProvider.ts
+++ b/src/features/ashCodeLensProvider.ts
@@ -107,18 +107,6 @@ export function registerAshCodeLensProvider(
 ): vscode.Disposable {
   const provider = new AshCodeLensProvider(parserService);
 
-  // Register a test command to verify command execution works
-  const testCommand = vscode.commands.registerCommand(
-    "ash-studio.testCodeLens",
-    async (url: string) => {
-      console.log(`[CodeLens Test] Test command called with URL: ${url}`);
-      vscode.window.showInformationMessage(`Code lens clicked! URL: ${url}`);
-    }
-  );
-
-  // Add the test command to context subscriptions
-  context.subscriptions.push(testCommand);
-
   // Register the provider for Elixir files
   const providerDisposable = vscode.languages.registerCodeLensProvider(
     { language: "elixir", scheme: "file" },
@@ -127,5 +115,5 @@ export function registerAshCodeLensProvider(
 
   context.subscriptions.push(providerDisposable);
 
-  return vscode.Disposable.from(testCommand, providerDisposable);
+  return vscode.Disposable.from(providerDisposable);
 }

--- a/test/unit/parser/blockExtractorService.test.ts
+++ b/test/unit/parser/blockExtractorService.test.ts
@@ -72,13 +72,6 @@ exampleFileTestCases.forEach(({ file, config, sections }) => {
       const blockExtractor = new BlockExtractorService();
       const result = blockExtractor.extractModules(source, [config]);
 
-      console.log(
-        "Sections found:",
-        result.map(s => s.section)
-      );
-      const attributesSection = result.find(s => s.section === "attributes");
-      console.log("Attributes section details:", attributesSection?.details);
-
       sections.forEach(({ name, detailCount, startLine, endLine }) => {
         const section = result.find(s => s.section === name);
         assert.ok(section, `Should find section: ${name}`);

--- a/test/unit/parser/diagramCodeLensService.test.ts
+++ b/test/unit/parser/diagramCodeLensService.test.ts
@@ -30,10 +30,6 @@ exampleFileTestCases.forEach(({ file, config, codeLenses }) => {
       const blocks = blockExtractor.extractModules(source, [config]);
       const service = new DiagramCodeLensService(config);
       const lenses = service.getCodeLenses(blocks, file);
-      console.log(
-        `Lenses for ${file}:`,
-        lenses.map(l => l.title)
-      );
       codeLenses.forEach(({ title }) => {
         const lens = lenses.find(l => l.title.endsWith(title));
         assert.ok(lens, `Should find code lens: ${title}`);


### PR DESCRIPTION
This PR removes the unused testCommand from the extension source and ensures there are no console.log statements in test files, addressing issue #11. All test output is now clean and uses proper assertions.