### PR TITLE
ci: fetch latest tag if blank and update Node.js to v20 in publish workflows

### DIFF
--- a/.github/workflows/open_vsx_publish.yml
+++ b/.github/workflows/open_vsx_publish.yml
@@ -24,18 +24,30 @@ jobs:
             echo "tag_name=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Get latest release tag (if tag is blank)
+        if: ${{ steps.set_tag.outputs.tag_name == '' }}
+        id: get_latest
+        run: |
+          tag=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+          echo "tag_name=$tag" >> $GITHUB_OUTPUT
+
+      - name: Use correct tag
+        id: resolved_tag
+        run: |
+          echo "Using tag ${{ steps.get_latest.outputs.tag_name || steps.set_tag.outputs.tag_name }}"
+
       - name: Download VSIX from Release
         uses: robinraju/release-downloader@v1.10
         with:
           repository: ${{ github.repository }}
-          tag: ${{ steps.set_tag.outputs.tag_name }}
+          tag: ${{ steps.get_latest.outputs.tag_name || steps.set_tag.outputs.tag_name }}
           fileName: "*.vsix"
           out-file-path: "."
 
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install ovsx CLI
         run: npm install -g ovsx

--- a/.github/workflows/vscode_marketplace_publish.yml
+++ b/.github/workflows/vscode_marketplace_publish.yml
@@ -24,18 +24,30 @@ jobs:
             echo "tag_name=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Get latest release tag (if tag is blank)
+        if: ${{ steps.set_tag.outputs.tag_name == '' }}
+        id: get_latest
+        run: |
+          tag=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+          echo "tag_name=$tag" >> $GITHUB_OUTPUT
+
+      - name: Use correct tag
+        id: resolved_tag
+        run: |
+          echo "Using tag ${{ steps.get_latest.outputs.tag_name || steps.set_tag.outputs.tag_name }}"
+
       - name: Download VSIX from Release
         uses: robinraju/release-downloader@v1.10
         with:
           repository: ${{ github.repository }}
-          tag: ${{ steps.set_tag.outputs.tag_name }}
+          tag: ${{ steps.get_latest.outputs.tag_name || steps.set_tag.outputs.tag_name }}
           fileName: "*.vsix"
           out-file-path: "."
 
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install vsce
         run: npm install -g @vscode/vsce


### PR DESCRIPTION
- Fetches the latest release tag if no tag is specified for publishing workflows
- Updates Node.js version to 20 in both VS Code Marketplace and OpenVSX publish workflows

This improves workflow robustness for manual and automated releases.