### PR TITLE
ci: add workflow to request Copilot review on PR open/ready/reopen

### DIFF
--- a/.github/workflows/request_copilot_review.yml
+++ b/.github/workflows/request_copilot_review.yml
@@ -15,5 +15,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              reviewers: ['github-copilot']
+              reviewers: ['github-copilot[bot]']
             })

--- a/.github/workflows/request_copilot_review.yml
+++ b/.github/workflows/request_copilot_review.yml
@@ -1,4 +1,7 @@
 name: Request Copilot Review
+permissions:
+  pull-requests: write
+  contents: read
 on:
   pull_request:
     types: [opened, ready_for_review, reopened]

--- a/.github/workflows/request_copilot_review.yml
+++ b/.github/workflows/request_copilot_review.yml
@@ -18,5 +18,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              reviewers: ["github-copilot[bot]"]
+              reviewers: []
             })

--- a/.github/workflows/request_copilot_review.yml
+++ b/.github/workflows/request_copilot_review.yml
@@ -1,0 +1,19 @@
+name: Request Copilot Review
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  copilot-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request Copilot Review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers: ['github-copilot[bot]']
+            })

--- a/.github/workflows/request_copilot_review.yml
+++ b/.github/workflows/request_copilot_review.yml
@@ -17,6 +17,5 @@ jobs:
             await github.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              reviewers: ['github-copilot[bot]']
+              pull_number: context.payload.pull_request.number
             })

--- a/.github/workflows/request_copilot_review.yml
+++ b/.github/workflows/request_copilot_review.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.pulls.requestReviewers({
+            await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number

--- a/.github/workflows/request_copilot_review.yml
+++ b/.github/workflows/request_copilot_review.yml
@@ -15,5 +15,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              team_reviewers: ['github-copilot']
+              reviewers: ['github-copilot']
             })

--- a/.github/workflows/request_copilot_review.yml
+++ b/.github/workflows/request_copilot_review.yml
@@ -15,5 +15,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              reviewers: ['github-copilot[bot]']
+              team_reviewers: ['github-copilot']
             })

--- a/.github/workflows/request_copilot_review.yml
+++ b/.github/workflows/request_copilot_review.yml
@@ -17,5 +17,6 @@ jobs:
             await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number
+              pull_number: context.payload.pull_request.number,
+              reviewers: ["github-copilot[bot]"]
             })


### PR DESCRIPTION
Adds a workflow that automatically requests a review from github-copilot[bot] when a pull request is opened, marked ready for review, or reopened.