### PR TITLE
docs: add direct marketplace and Open VSX links to README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ helping you quickly jump between Ash DSL blocks and understand your code structu
 
 ## 📦 Installation
 
-### From the VSCode Extensions Store
+### From the Your Extensions Store
 
-1. Search for Ash Studio
+1. Search for Ash Studio or
+   - [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ketupia.ash-studio)
+   - [Open VSX (Windsurf/Cursor)](https://open-vsx.org/extension/ketupia/ash-studio)
 2. Click install
 
 ### From VSIX File

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ helping you quickly jump between Ash DSL blocks and understand your code structu
 
 ## 📦 Installation
 
-### From the Your Extensions Store
+### From Your Extensions Store
 
 1. Search for Ash Studio or
    - [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ketupia.ash-studio)


### PR DESCRIPTION
This PR updates the README to include direct links to the VS Code Marketplace and Open VSX in the installation section, making it easier for users to find and install the extension.