### PR TITLE
fix: ensure mix command spawns with shell:true on Windows for cross-platform compatibility

### DIFF
--- a/src/utils/diagramMixUtils.ts
+++ b/src/utils/diagramMixUtils.ts
@@ -43,7 +43,9 @@ export async function generateDiagramWithMix(
     }
     let mix: ReturnType<typeof spawn>;
     try {
-      mix = spawn("mix", args, { cwd });
+      // On Windows, use shell: true so that mix.bat/cmd is resolved correctly
+      const isWindows = process.platform === "win32";
+      mix = spawn("mix", args, { cwd, shell: isWindows });
     } catch (syncErr) {
       vscode.window.showErrorMessage(
         `Failed to start Mix: ${syncErr instanceof Error ? syncErr.message : String(syncErr)}`

--- a/src/utils/diagramMixUtils.ts
+++ b/src/utils/diagramMixUtils.ts
@@ -43,7 +43,12 @@ export async function generateDiagramWithMix(
     }
     let mix: ReturnType<typeof spawn>;
     try {
-      // On Windows, use shell: true so that mix.bat/cmd is resolved correctly
+      /**
+       * On Windows, the "mix" command is typically a batch file (mix.bat or mix.cmd).
+       * Node.js's spawn requires the "shell: true" option to resolve and execute batch files correctly.
+       * On other platforms, "mix" is usually an executable and does not require the shell option.
+       * This platform check ensures compatibility across operating systems.
+       */
       const isWindows = process.platform === "win32";
       mix = spawn("mix", args, { cwd, shell: isWindows });
     } catch (syncErr) {


### PR DESCRIPTION
This PR updates the diagram generation logic to use `{ shell: true }` when spawning the `mix` command on Windows. This ensures that `mix.bat` or `mix.cmd` is resolved correctly, fixing issues with running Mix tasks on Windows platforms.

- Uses `process.platform === "win32"` to detect Windows
- No changes to project root detection (still uses `mix.exs`)
- No impact on macOS/Linux

Closes #24