### PR TITLE
feat: Show child entries in Symbols and Outline views

### DIFF
--- a/.github/workflows/pr_codeql.yml
+++ b/.github/workflows/pr_codeql.yml
@@ -17,21 +17,39 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout code to analyze
+      - name: Determine repo and ref to analyze
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual run: analyze the repo/sha/branch specified by the user
+            echo "ref=${{ github.event.inputs.ref }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
+          else
+            # PR event: analyze the PR head (works for forks)
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout code to analyze (PR head or provided ref)
         uses: actions/checkout@v4
         with:
-          # If run via workflow_dispatch, use the provided input; otherwise use the PR head SHA
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.event.pull_request.head.sha }}
+          repository: ${{ steps.vars.outputs.repo }}
+          ref: ${{ steps.vars.outputs.ref }}
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: javascript, typescript
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
+        with:
+          # optional: upload-database: true
+          wait-for-processing: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,8 @@ module.exports = {
   testEnvironment: "node",
   testMatch: ["**/test/**/*.test.ts"],
   moduleFileExtensions: ["ts", "js", "json", "node"],
+  moduleNameMapper: {
+    "^vscode$": "<rootDir>/test/__mocks__/vscode.ts",
+  },
+  modulePathIgnorePatterns: ["<rootDir>/dist/"],
 };

--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
           ],
           "default": "auto-delete",
           "description": "Controls lifecycle of generated diagram files. `auto-delete` will remove generated .mmd after reading. `generate-only` will generate (if missing or outdated) but leave the file in place for inspection."
+        },
+        "ashStudio.showChildrenInOutlineAndSymbols": {
+          "type": "boolean",
+          "default": false,
+          "description": "Adds the children of the dsl sections to the Outline and Symbols views"
         }
       }
     }

--- a/src/configurations/Ash.Resource.config.ts
+++ b/src/configurations/Ash.Resource.config.ts
@@ -1,3 +1,4 @@
+import { SymbolKind } from "vscode";
 import {
   ModuleConfiguration,
   namePatterns,
@@ -9,6 +10,7 @@ const Ash_Resource_Config: ModuleConfiguration = {
   dslSections: [
     {
       name: "actions",
+      symbol: SymbolKind.Method,
       childPatterns: [
         {
           keyword: "create",
@@ -39,6 +41,7 @@ const Ash_Resource_Config: ModuleConfiguration = {
     },
     {
       name: "aggregates",
+      symbol: SymbolKind.Variable,
       childPatterns: [
         {
           keyword: "count",
@@ -87,6 +90,7 @@ const Ash_Resource_Config: ModuleConfiguration = {
     },
     {
       name: "attributes",
+      symbol: SymbolKind.Field,
       childPatterns: [
         {
           keyword: "attribute",
@@ -97,6 +101,7 @@ const Ash_Resource_Config: ModuleConfiguration = {
     },
     {
       name: "calculations",
+      symbol: SymbolKind.Property,
       childPatterns: [
         {
           keyword: "calculate",
@@ -115,6 +120,7 @@ const Ash_Resource_Config: ModuleConfiguration = {
     },
     {
       name: "code_interface",
+      symbol: SymbolKind.Method,
       childPatterns: [
         {
           keyword: "define",
@@ -133,6 +139,7 @@ const Ash_Resource_Config: ModuleConfiguration = {
     },
     {
       name: "policies",
+      symbol: SymbolKind.Property,
       childPatterns: [
         {
           keyword: "bypass",
@@ -154,6 +161,7 @@ const Ash_Resource_Config: ModuleConfiguration = {
     },
     {
       name: "relationships",
+      symbol: SymbolKind.Interface,
       childPatterns: [
         {
           keyword: "belongs_to",

--- a/src/parser/sectionParser.ts
+++ b/src/parser/sectionParser.ts
@@ -68,6 +68,7 @@ export class SectionParser {
                 startingLocation: { line: i + 1, column },
                 endingLocation: { line: 0, column: 0 },
                 children: [],
+                symbol: dslSection.symbol,
               },
             });
             break; // Only one section per line

--- a/src/types/configurationRegistry.ts
+++ b/src/types/configurationRegistry.ts
@@ -7,6 +7,8 @@
  * describing how its DSL sections and keywords should be parsed, displayed, and visualized in VS Code.
  */
 
+import { SymbolKind } from "vscode";
+
 /**
  * Interface for the configuration registry class.
  */
@@ -130,6 +132,8 @@ export interface DslSection {
    * Array of child patterns to search for within this root section's content.
    */
   childPatterns?: ChildPattern[];
+
+  symbol?: SymbolKind;
 }
 
 /**

--- a/src/types/parser.ts
+++ b/src/types/parser.ts
@@ -1,6 +1,7 @@
 // Centralized Ash parser types and interfaces for use across the extension
 // Only export public APIs. Document each interface/type clearly.
 
+import { SymbolKind } from "vscode";
 import { DiagramSpec } from "./configurationRegistry";
 
 /**
@@ -33,6 +34,7 @@ export interface ParsedSection {
   children: ParsedChild[]; // parsed children within this section (renamed from details)
   startingLocation: ParsedLocation; // starting location info for this section
   endingLocation: ParsedLocation; // ending location info for this section
+  symbol?: SymbolKind;
 }
 
 export interface DiagramCodeLensEntry {

--- a/src/vscode/providers/documentSymbolProvider.ts
+++ b/src/vscode/providers/documentSymbolProvider.ts
@@ -53,7 +53,7 @@ export function registerDocumentSymbolProvider(
 
         const cfg = vscode.workspace.getConfiguration("ashStudio");
 
-        if (cfg.get<boolean>("showChildrenInOutlineAndSymbols", true)) {
+        if (cfg.get<boolean>("showChildrenInOutlineAndSymbols", false)) {
           const children = getChildrenSymbols(section);
           if (children.length > 0) {
             sectionSymbol.children = children;

--- a/src/vscode/providers/documentSymbolProvider.ts
+++ b/src/vscode/providers/documentSymbolProvider.ts
@@ -31,6 +31,12 @@ export function registerDocumentSymbolProvider(
         `Found ${parseResult.sections.length} sections: ${parseResult.sections.map(s => s.name).join(", ")}`
       );
 
+      const cfg = vscode.workspace.getConfiguration("ashStudio");
+      const showChildrenInOutlineAndSymbols = cfg.get<boolean>(
+        "showChildrenInOutlineAndSymbols",
+        false
+      );
+
       // Return main DSL sections with nested children if config flag is set
       const symbols = parseResult.sections.map((section: ParsedSection) => {
         const startPos = new vscode.Position(
@@ -51,9 +57,7 @@ export function registerDocumentSymbolProvider(
           new vscode.Range(startPos, startPos)
         );
 
-        const cfg = vscode.workspace.getConfiguration("ashStudio");
-
-        if (cfg.get<boolean>("showChildrenInOutlineAndSymbols", false)) {
+        if (showChildrenInOutlineAndSymbols) {
           const children = getChildrenSymbols(section);
           if (children.length > 0) {
             sectionSymbol.children = children;

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -1,0 +1,47 @@
+export enum SymbolKind {
+  File = 1,
+  Module,
+  Namespace,
+  Package,
+  Class,
+  Method,
+  Property,
+  Field,
+  Constructor,
+  Enum,
+  Interface,
+  Function,
+  Variable,
+}
+
+export const languages = {
+  registerDefinitionProvider: () => ({ dispose: () => {} }),
+};
+
+export class Position {
+  constructor(
+    public line: number,
+    public character: number
+  ) {}
+}
+
+export class Location {
+  constructor(
+    public uri: any,
+    public position: Position
+  ) {}
+}
+
+export const workspace = {};
+
+export const window = {
+  showInformationMessage: () => {},
+};
+
+export const ExtensionContext = function () {} as any;
+
+export const DefinitionProvider = class {} as any;
+
+export const ProviderResult = null as any;
+
+export default {} as any;

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -27,21 +27,27 @@ export class Position {
 
 export class Location {
   constructor(
-    public uri: any,
+    public uri: unknown,
     public position: Position
   ) {}
 }
 
-export const workspace = {};
+export const workspace = {};  
 
 export const window = {
   showInformationMessage: () => {},
 };
 
-export const ExtensionContext = function () {} as any;
+export interface ExtensionContext {
+  subscriptions?: { dispose(): void }[];
+}
 
-export const DefinitionProvider = class {} as any;
+export const createExtensionContext = (): ExtensionContext => ({
+  subscriptions: [],
+});
 
-export const ProviderResult = null as any;
+export class DefinitionProvider {}
 
-export default {} as any;
+export type ProviderResult<T> = T | undefined | null;
+
+export default {};


### PR DESCRIPTION
This PR adds the option to add the child sections to the Outlie and Symbols views. This makes it possible to quickly navigate to child sections using the Symbols Search (`ctrl`+`shift`+`o`)

* Added a `symbol` configuration option to the `DslSection` configuration to configure what symbol to show in the outline:
<img width="327" height="291" alt="image" src="https://github.com/user-attachments/assets/5b588b87-e29c-4b39-8b87-6f374c4957bd" />



* Added the `ashStudio.showChildrenInOutlineAndSymbols` configuration option to toggle whether to show the children in the Symbols and Outline views

<img width="567" height="83" alt="image" src="https://github.com/user-attachments/assets/09ae362e-062f-4a8a-b81d-49ae0892065d" />
